### PR TITLE
Python3 support

### DIFF
--- a/usdt/__init__.py
+++ b/usdt/__init__.py
@@ -4,16 +4,16 @@
 libusdt bindings for Python
 """
 
+import os
+from ctypes import cdll, c_char_p, c_int, c_void_p, cast, POINTER
 from __future__ import print_function
+
 __author__ = 'Nahum Shalman'
 __email__ = 'nshalman-github@elys.com'
 __version__ = '0.1.2dev'
 
 HAVE_USDT = False
 FAKE_DTRACE = False
-
-import os
-from ctypes import cdll, c_char_p, c_int, c_void_p, cast, POINTER
 
 try:
     HERE = os.path.dirname(os.path.realpath(__file__))
@@ -32,6 +32,7 @@ if HAVE_USDT:
 
     class Probe(object):
         """ a USDT probe """
+
         def __init__(self, func, name, arg_desc):
             self._LIBUSDT = _LIBUSDT
             self.length = len(arg_desc)
@@ -39,7 +40,7 @@ if HAVE_USDT:
             for i in range(self.length):
                 args[i] = arg_desc[i]
             self.probedef = self._LIBUSDT.usdt_create_probe(func,
-                    name, self.length, args)
+                                                            name, self.length, args)
 
         def fire(self, args):
             """ fire the probe """
@@ -57,6 +58,7 @@ if HAVE_USDT:
 
     class Provider(object):
         """ a USDT provider """
+
         def __init__(self, provider="python-dtrace", module="default_module"):
             self._LIBUSDT = _LIBUSDT
             self.provider = self._LIBUSDT.usdt_create_provider(provider, module)
@@ -84,6 +86,7 @@ else:
 
     class Probe(object):
         """ a fake USDT probe """
+
         def __init__(self, name, func, arg_desc):
             self.name = name
             self.func = func
@@ -94,8 +97,8 @@ else:
             """ send probe info to stderr if requested """
             if FAKE_DTRACE and self.provider and self.provider.enabled:
                 print(self.provider.provider, self.provider.module,
-                        self.name, self.func, args,
-                        file=stderr)
+                      self.name, self.func, args,
+                      file=stderr)
 
         def __del__(self):
             pass

--- a/usdt/__init__.py
+++ b/usdt/__init__.py
@@ -4,9 +4,9 @@
 libusdt bindings for Python
 """
 
+from __future__ import print_function
 import os
 from ctypes import cdll, c_char_p, c_int, c_void_p, cast, POINTER
-from __future__ import print_function
 
 __author__ = 'Nahum Shalman'
 __email__ = 'nshalman-github@elys.com'

--- a/usdt/build_hooks.py
+++ b/usdt/build_hooks.py
@@ -23,6 +23,6 @@ def post_build():
     try:
         if os.system("cd %s ; make %s clean all" % (libdir, extra)) == 0:
             os.system("gcc -g -shared -o %s -Wl,%s %s" %
-                    (library, linker_flag, source))
+                      (library, linker_flag, source))
     except:
         pass

--- a/usdt/build_hooks.py
+++ b/usdt/build_hooks.py
@@ -14,7 +14,7 @@ def post_build():
 
     linker_flag = "--whole-archive"
     compiler = subprocess.check_output(["cc", "--version"])
-    if "clang" in compiler:
+    if b"clang" in compiler:
         linker_flag = "-force_load"
 
     libdir = os.getcwd() + "/build/lib/usdt/libusdt"

--- a/usdt/log.py
+++ b/usdt/log.py
@@ -5,7 +5,7 @@ Tools for logging that leverage USDT
 """
 
 from usdt import Probe, Provider
-import  logging
+import logging
 
 _LEVELS = [logging.CRITICAL, logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG, logging.NOTSET]
 _DESC = {
@@ -17,8 +17,10 @@ _DESC = {
     logging.NOTSET: "notset",
 }
 
+
 class DtraceHandler(logging.Handler):
     """ Handler to fire USDT probes with log messages """
+
     def __init__(self):
         logging.Handler.__init__(self)
 

--- a/usdt/tracer.py
+++ b/usdt/tracer.py
@@ -7,10 +7,12 @@ Tracing tools built on USDT
 from usdt import Probe, Provider
 import functools
 
+
 class fbt(object):
     """
     simple function boundary tracing decorator
     """
+
     def __init__(self, func):
         self.func = func
         probename = func.__name__


### PR DESCRIPTION
This PR adds support for building on Python3, which previously failed with following error: 

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/h9/m_gf3cvx3yj04tfv8g4h1mzc0000gn/T/pip-build-uu3gaavd/usdt/setup.py", line 62, in <module>
        cmdclass={'build_py': build_py_}
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/Users/xenol/.virtualenvs/usdt3/lib/python3.5/site-packages/setuptools/command/install.py", line 61, in run
        return orig.install.run(self)
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/command/install.py", line 539, in run
        self.run_command('build')
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/command/build.py", line 135, in run
        self.run_command(cmd_name)
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/private/var/folders/h9/m_gf3cvx3yj04tfv8g4h1mzc0000gn/T/pip-build-uu3gaavd/usdt/setup.py", line 28, in run
        build_hooks.post_build()
      File "build/lib/usdt/build_hooks.py", line 17, in post_build
        if "clang" in compiler:
    TypeError: a bytes-like object is required, not 'str'

I also did some PEP8 cleanup.